### PR TITLE
Add handling for Git Submodules

### DIFF
--- a/src/commit-message.js
+++ b/src/commit-message.js
@@ -1,15 +1,25 @@
 var Q = require('q');
 var exists = require('fs').existsSync;
+var fileInfo = require('fs').lstatSync;
 var read = require('fs').readFileSync;
 var filename = './.git/COMMIT_EDITMSG';
 
 function commitMessage() {
-  if (!exists(filename)) {
-    return Q.reject(new Error('Cannot find file ' + filename));
+  var commitMsgFile = filename;
+  if(!fileInfo('./.git').isDirectory()) {
+    var unparsedText = "" + read('./.git');
+    console.log("ParsedText: " + unparsedText.substring('gitdir: '.length).trim());
+    commitMsgFile = unparsedText.substring('gitdir: '.length).trim() + '/COMMIT_EDITMSG';
   }
-  var text = read(filename, 'utf8');
+
+  if (!exists(commitMsgFile)) {
+      return Q.reject(new Error('Cannot find file ' + commitMsgFile));
+  }
+
+  var text = read(commitMsgFile, 'utf8');
   /* jshint -W064 */
   return Q(text);
+
 }
 
 module.exports = commitMessage;


### PR DESCRIPTION
If .git is actually a file and not a directory, we're in a submodule and .git is actually a 'pointer' file that tells us where the actual .git dir contents are.

  This change checks to see if the file is a directory and, if it's not, naively loads the contents of the file assuming it only contains 'gitdir: <directory location>'