### PR TITLE
feat(tags): allow fetch tags accessible from a branch

### DIFF
--- a/docs/commits.md
+++ b/docs/commits.md
@@ -21,9 +21,9 @@ commits.all(gitRepoFolder)
 
 Each object has at least 'id', 'message' and (maybe empty) 'body' properties.
 
-You can also return just the commits after the last version tag
-(which usually starts with 'v'). This is useful for semantic release
-code.
+You can also return just the commits starting from the last version tag
+(which usually starts with 'v') on the current branch. This is useful
+for semantic release code.
 
 ```sh
 var commits = require('ggit').commits;

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -15,11 +15,40 @@ tags().then(function (list) {
 })
 ```
 You can return just tags that start with "v" by passing
-flag
+`true` to `tags`.
 
 ```js
 tags(true).then(function (list) {...})
 ```
 
 Oldest tag is returns as first object, latest tag is the
+last object in the list.
+
+## branchTags
+
+Similar to `tags`, `branchTags` returns tags in the given folder,
+but only those tags accessible from the current branch. Any tags
+in the repository that point to a commit on another branch will
+not be returned by `branchTags`.
+
+```js
+var branchTags = require('ggit').branchTags;
+branchTags().then(function (list) {
+  /*
+    each object in list is like
+  {
+    "commit": "7756b5609c5aae651f267fa3fc00763bcd276bf6",
+    "tag": "v1.3.0"
+  }
+  */
+})
+```
+You can return just tags that start with "v" by passing
+`true` to `branchTags`.
+
+```js
+branchTags(true).then(function (list) {...})
+```
+
+Oldest tag is returned as first object, latest tag is the
 last object in the list.

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ var actions = {
 	commitMessage: require('./src/commit-message'),
 	getGitFolder: require('./src/git-folder'),
 	tags: require('./src/tags'),
+	branchTags: require('./src/tags').getBranchTags,
 	fetchTags: require('./src/fetch-tags')
 };
 

--- a/src/commits.js
+++ b/src/commits.js
@@ -7,7 +7,7 @@ la(check.fn(getOneLineLog), 'missing one line log function');
 var fs = require('fs');
 var folders = require('chdir-promise');
 var R = require('ramda');
-var getTags = require('./tags');
+var getBranchTags = require('./tags').getBranchTags;
 
 function getLog() {
   return getOneLineLog({ full: true });
@@ -57,7 +57,7 @@ function afterLastTag(vTagsOnly) {
   return commits()
     .then(function (list) {
       vTagsOnly = vTagsOnly !== false ? true: false;
-      return getTags(vTagsOnly)
+      return getBranchTags(vTagsOnly)
         .then(function (tags) {
           if (check.empty(tags)) {
             return list;

--- a/src/tags.js
+++ b/src/tags.js
@@ -51,6 +51,17 @@ function parseTags(vTagsOnly, text) {
   return lines;
 }
 
+function getBranchTags(vTagsOnly) {
+  // returns each tag on its own line
+  // oldest tags first, latest tags last]
+  // only tags accessible from the current branch are returned
+  var cmd = 'git tag --sort version:refname --merged';
+  var parseSomeTags = parseTags.bind(null, vTagsOnly);
+  return exec(cmd)
+    .then(parseSomeTags)
+    .then(getCommitIds);
+}
+
 function getTags (vTagsOnly) {
   // returns each tag on its own line
   // oldest tags first, latest tags last
@@ -60,5 +71,7 @@ function getTags (vTagsOnly) {
     .then(parseSomeTags)
     .then(getCommitIds);
 }
+
+getTags.getBranchTags = getBranchTags;
 
 module.exports = getTags;


### PR DESCRIPTION
Add new function, `branchTags`, that allows you to fetch all git tags
accessible from a branch. Tags pointing at commits only accessible from
other branches will not be returned in the array returned by
`branchTags`.

Closes #44 