### PR TITLE
fix(getLogAfter): use typeof for node 4.x

### DIFF
--- a/src/commits.js
+++ b/src/commits.js
@@ -15,11 +15,11 @@ function getLog () {
   return getOneLineLog({ full: true })
 }
 
-function getLogAfter (commit, branchName = 'master') {
+function getLogAfter (commit, branchName) {
   return getOneLineLog({
     full: true,
     from: commit,
-    firstParent: branchName
+    firstParent: typeof branchName === 'undefined' ? 'master' : branchName
   })
 }
 


### PR DESCRIPTION
Ensures compatibility with earlier node.js version (4.x.x), where `= branchName` would throw.